### PR TITLE
Set the visibility of the card body view's suit grid based on rank

### DIFF
--- a/PlayingCards/CardBodyRankView.swift
+++ b/PlayingCards/CardBodyRankView.swift
@@ -8,19 +8,11 @@
 
 import UIKit
 
-private let DetailSuitViewGridColumnCount = 3
-private let DetailSuitViewGridRowCount = 7
+let DetailSuitViewGridColumnCount = 3
+let DetailSuitViewGridRowCount = 7
 
 class CardBodyRankView: UIView {
 
-    private var rank: Rank = .ace {
-        didSet {
-        }
-    }
-    private var suit: Suit = .spade {
-        didSet {
-        }
-    }
     private lazy var detailSuitViewGrid: [[SuitDetailView]] = {
         var suitViews = [[SuitDetailView]]()
         for _ in 0..<DetailSuitViewGridColumnCount {
@@ -46,8 +38,12 @@ class CardBodyRankView: UIView {
     }
 
     public func configure(rank: Rank, suit: Suit) {
-        self.rank = rank
-        self.suit = suit
+        let visibilityGrid = CardBodyRankView.suitVisibilityGrid(for: rank)
+        for (columnIndex, column) in detailSuitViewGrid.enumerated() {
+            for (rowIndex, detailView) in column.enumerated() {
+                detailView.isHidden = !visibilityGrid[columnIndex][rowIndex]
+            }
+        }
     }
 
     private func setup() {
@@ -67,19 +63,19 @@ class CardBodyRankView: UIView {
         // Detail View Height and Width
         detailSuitViewGrid.joined().apply() {
             let widthConstraint = NSLayoutConstraint(item: $0,
-                attribute: .width,
-                relatedBy: .equal,
-                toItem: self,
-                attribute: .width,
-                multiplier: (1 / CGFloat(DetailSuitViewGridColumnCount)),
-                constant: 0)
+                                                     attribute: .width,
+                                                     relatedBy: .equal,
+                                                     toItem: self,
+                                                     attribute: .width,
+                                                     multiplier: (1 / CGFloat(DetailSuitViewGridColumnCount)),
+                                                     constant: 0)
             let heightConstraint = NSLayoutConstraint(item: $0,
-                attribute: .height,
-                relatedBy: .equal,
-                toItem: self,
-                attribute: .height,
-                multiplier: (1 / CGFloat(DetailSuitViewGridRowCount)),
-                constant: 0)
+                                                      attribute: .height,
+                                                      relatedBy: .equal,
+                                                      toItem: self,
+                                                      attribute: .height,
+                                                      multiplier: (1 / CGFloat(DetailSuitViewGridRowCount)),
+                                                      constant: 0)
             addConstraints([widthConstraint, heightConstraint])
         }
 
@@ -113,6 +109,89 @@ class CardBodyRankView: UIView {
     }
 }
 
+extension CardBodyRankView {
+    static func suitVisibilityGrid(for rank: Rank) -> [[Bool]] {
+        switch rank {
+        case .ace:
+            return [
+                [false, false, false, false, false, false, false],
+                [false, false, false, true, false, false, false],
+                [false, false, false, false, false, false, false]
+            ]
+
+        case .ten:
+            return [
+                [true, false, true, false, true, false, true],
+                [false, true, false, false, false, true, false],
+                [true, false, true, false, true, false, true]
+            ]
+
+        case .nine:
+            return [
+                [true, false, true, false, true, false, true],
+                [false, false, false, true, false, false, false],
+                [true, false, true, false, true, false, true]
+            ]
+
+        case .eight:
+            return [
+                [true, false, false, true, false, false, true],
+                [false, false, true, false, true, false, false],
+                [true, false, false, true, false, false, true]
+            ]
+
+        case .seven:
+            return [
+                [true, false, false, false, false, false, true],
+                [false, true, false, true, false, true, false],
+                [true, false, false, false, false, false, true]
+            ]
+
+        case .six:
+            return [
+                [true, false, false, true, false, false, true],
+                [false, false, false, false, false, false, false],
+                [true, false, false, true, false, false, true]
+            ]
+
+        case .five:
+            return [
+                [true, false, false, false, false, false, true],
+                [false, false, false, true, false, false, false],
+                [true, false, false, false, false, false, true]
+            ]
+
+        case .four:
+            return [
+                [true, false, false, false, false, false, true],
+                [false, false, false, false, false, false, false],
+                [true, false, false, false, false, false, true]
+            ]
+
+        case .three:
+            return [
+                [false, false, false, false, false, false, false],
+                [true, false, false, true, false, false, true],
+                [false, false, false, false, false, false, false]
+            ]
+
+        case .two:
+            return [
+                [false, false, false, false, false, false, false],
+                [true, false, false, false, false, false, true],
+                [false, false, false, false, false, false, false]
+            ]
+
+        case .king, .queen, .jack:
+            return [
+                [false, false, false, false, false, false, false],
+                [false, false, false, false, false, false, false],
+                [false, false, false, false, false, false, false]
+            ]
+        }
+    }
+}
+
 private class SuitDetailView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -128,7 +207,6 @@ private class SuitDetailView: UIView {
         backgroundColor = UIColor.randomColor()
     }
 }
-
 
 // TODO: rcedwards REMOVE THIS. JUST FOR TESTING LAYOUT
 

--- a/PlayingCards/CardView.swift
+++ b/PlayingCards/CardView.swift
@@ -110,6 +110,8 @@ open class CardView: UIView {
     open func configure(rank: Rank, suit: Suit) {
         self.rank = rank
         self.suit = suit
+
+        bodyRankView.configure(rank: rank, suit: suit)
     }
 
     private func setup() {

--- a/PlayingCards/CardViewPlayground.playground/Contents.swift
+++ b/PlayingCards/CardViewPlayground.playground/Contents.swift
@@ -1,12 +1,11 @@
 //: Playground - noun: a place where people can play
 
 import UIKit
-import XCPlayground
+import PlaygroundSupport
 
 import PlayingCards
 
 
 let card = CardView(frame: CGRect(x: 0, y: 0, width: 144, height: 200))
-card.configure(.King, suit: .Heart)
-
-XCPlaygroundPage.currentPage.liveView = card
+card.configure(rank: .ten, suit: .heart)
+PlaygroundPage.current.liveView = card

--- a/PlayingCardsTests/CardBodyRankViewTests.swift
+++ b/PlayingCardsTests/CardBodyRankViewTests.swift
@@ -1,0 +1,56 @@
+//
+//  CardBodyRankViewTests.swift
+//  TienLen
+//
+//  Created by Robert Edwards on 9/19/16.
+//  Copyright © 2016 Panko. All rights reserved.
+//
+
+import XCTest
+
+@testable import PlayingCards
+
+class CardBodyRankViewTests: XCTestCase {
+
+    func testSuitDetailGridVisibility() {
+        for rank in Rank.allRanks {
+            let grid = CardBodyRankView.suitVisibilityGrid(for: rank)
+            XCTAssertEqual(grid.count, DetailSuitViewGridColumnCount)
+            for column in grid {
+                XCTAssertEqual(column.count, DetailSuitViewGridRowCount)
+            }
+
+            let visibleElements = grid.flatMap() { return $0.filter() { v in return v } }
+            XCTAssertEqual(visibleElements.count, CardBodyRankViewTests.expectedVisibleViewCount(for: rank),
+                           "Failed for rank: \(rank)")
+        }
+    }
+
+    static func expectedVisibleViewCount(for rank: Rank) -> Int {
+        switch rank {
+        case .ace:
+            return 1
+        case .two:
+            return 2
+        case .three:
+            return 3
+        case .four:
+            return 4
+        case .five:
+            return 5
+        case .six:
+            return 6
+        case .seven:
+            return 7
+        case .eight:
+            return 8
+        case .nine:
+            return 9
+        case .ten:
+            return 10
+        case .jack, .queen, .king:
+            return 0
+        }
+    }
+    
+}

--- a/TienLen.xcodeproj/project.pbxproj
+++ b/TienLen.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D4638A1D1CA82A43009F81C6 /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4638A1C1CA82A43009F81C6 /* Cards.swift */; };
+		E40B2C4C1D90CF88003E5246 /* CardBodyRankViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40B2C4B1D90CF88003E5246 /* CardBodyRankViewTests.swift */; };
 		E41027C71CC286B6008A6A46 /* UIColor+Onward.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41027C61CC286B6008A6A46 /* UIColor+Onward.swift */; };
 		E41CB0DC1CBAB414006F247F /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41CB0DB1CBAB414006F247F /* CardView.swift */; };
 		E41CB0F31CBC1B39006F247F /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41CB0F21CBC1B39006F247F /* MainViewController.swift */; };
@@ -91,6 +92,7 @@
 
 /* Begin PBXFileReference section */
 		D4638A1C1CA82A43009F81C6 /* Cards.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cards.swift; sourceTree = "<group>"; };
+		E40B2C4B1D90CF88003E5246 /* CardBodyRankViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBodyRankViewTests.swift; sourceTree = "<group>"; };
 		E41027C61CC286B6008A6A46 /* UIColor+Onward.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Onward.swift"; sourceTree = "<group>"; };
 		E41CB0DB1CBAB414006F247F /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		E41CB0F21CBC1B39006F247F /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				E45ED9F11C700E8500FE3B95 /* GameTests.swift */,
 				E45ED9F21C700E8500FE3B95 /* RankTests.swift */,
 				E45ED9F31C700E8500FE3B95 /* SuitTests.swift */,
+				E40B2C4B1D90CF88003E5246 /* CardBodyRankViewTests.swift */,
 				E45ED9E31C700DE500FE3B95 /* Supporting Files */,
 			);
 			path = PlayingCardsTests;
@@ -689,6 +692,7 @@
 			files = (
 				E45ED9F51C700E8500FE3B95 /* DeckTests.swift in Sources */,
 				E45ED9F71C700E8500FE3B95 /* RankTests.swift in Sources */,
+				E40B2C4C1D90CF88003E5246 /* CardBodyRankViewTests.swift in Sources */,
 				E45ED9F81C700E8500FE3B95 /* SuitTests.swift in Sources */,
 				E45ED9F61C700E8500FE3B95 /* GameTests.swift in Sources */,
 				E45ED9F41C700E8500FE3B95 /* CardTests.swift in Sources */,


### PR DESCRIPTION
There's probably a much DRYer way of doing this but this seems to be pretty reliable and under test.
Should do for now.

<img width="733" alt="screenshot 2016-09-19 22 25 47" src="https://cloud.githubusercontent.com/assets/573823/18655573/0c9b7758-7eb8-11e6-9751-b51038424237.png">
